### PR TITLE
Fixed Typo in PeerMessage.java

### DIFF
--- a/src-java/peerbase/PeerMessage.java
+++ b/src-java/peerbase/PeerMessage.java
@@ -111,7 +111,7 @@ public class PeerMessage {
 	 * @return the message type (4-byte array)
 	 */
 	public byte[] getMsgTypeBytes() {
-		return (byte[])data.clone();
+		return (byte[])type.clone();
 	}
 	
 	


### PR DESCRIPTION
Method getMsgTypeBytes was returning data bytes